### PR TITLE
Aux out setter problem

### DIFF
--- a/stanford_research/SR844.py
+++ b/stanford_research/SR844.py
@@ -350,7 +350,7 @@ class SR844(VisaInstrument):
                                label='Aux output {}'.format(i),
                                get_cmd='AUXO? {}'.format(i),
                                get_parser=float,
-                               set_cmd='AUXV {0}, {{}}'.format(i),
+                               set_cmd='AUXO {0}, {{}}'.format(i),
                                unit='V')
 
         # Setup


### PR DESCRIPTION
Today we tried to set the voltage of aux out and found out that the setter command is invalid. For SR830 the setter is AUXV ... and for SR840 it is AUXO. We tested with AUXO and it worked.